### PR TITLE
replace instead of modifying uppercase & lowercase

### DIFF
--- a/src/ICU.jl
+++ b/src/ICU.jl
@@ -18,9 +18,6 @@ require("UTF16")
 module ICU
 using UTF16
 
-import Base.lowercase,
-       Base.uppercase
-
 export foldcase,
        lowercase,
        set_locale,


### PR DESCRIPTION
Instead of modifying the Base.{lowercase,uppercase}, this defines new
lowercase and uppercase functions which will be used instead of the
ones in Base as long as one does `using ICU`. This also avoids a
warning on loading of the ICU module.
