### PR TITLE
Add more options for possible symbol names.

### DIFF
--- a/src/ICU.jl
+++ b/src/ICU.jl
@@ -27,7 +27,7 @@ export foldcase,
 const iculib = dlopen(OS_NAME == :Darwin ? "libicucore" : "libicuuc")
 const iculibi18n = OS_NAME == :Darwin ? iculib : dlopen("libicui18n")
 
-for suffix in ["", ["_"*string(i) for i in 42:50]]
+for suffix in ["", ["_"*string(i) for i in 42:50], ["_"*string(i)[1]*"_"*string(i)[2] for i in 42:50]]
     if dlsym_e(iculib, "u_strToUpper"*suffix) != C_NULL
         for f in (:u_strFoldCase,
                   :u_strToLower,


### PR DESCRIPTION
It looks like some OS's have extra underscores in the symbol names for the libicuuc functions.  I am  using CentOS 6 and get this:

```
$ readelf -Ws /usr/lib64/libicuuc.so.42 | awk '{print $8}' | grep ucasemap_open
ucasemap_open_4_2
```

This commit just adds some more options to work for this type of numbering.
