### PR TITLE
try a few even older versions

### DIFF
--- a/deps/versions.jl
+++ b/deps/versions.jl
@@ -1,1 +1,1 @@
-versions = 52:-1:40
+versions = 52:-1:36


### PR DESCRIPTION
needed for RHEL5 - otherwise I was getting

```
julia> using ICU
ERROR: _ucasemap_open not defined
 in set_locale at /home/tkelman/.julia/v0.3/ICU/src/ICU.jl:147
```
