### PR TITLE
Update to work with v0.4 as well as v0.3

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,7 @@
 using BinDeps
 
+using Compat
+
 include("versions.jl")
 
 @BinDeps.setup
@@ -22,7 +24,7 @@ icui18n = library_dependency("icui18n", aliases=i18n_aliases)
     using WinRPM
     provides(WinRPM.RPM, "icu", [icu,icui18n], os=:Windows)
 end
-provides(AptGet, {"libicu$v" => [icu,icui18n] for v in apt_versions})
+provides(AptGet, @compat Dict(["libicu$v" => [icu,icui18n] for v in apt_versions]))
 provides(Yum, "icu", [icu, icui18n])
 
-@BinDeps.install [:icu => :iculib, :icui18n => :iculibi18n]
+@BinDeps.install @compat Dict(:icu => :iculib, :icui18n => :iculibi18n)


### PR DESCRIPTION
Use better typing (Cstring instead of Ptr{Uint8}, Ptr{UChar} instead of Ptr{Uint16}
Add finalizers to avoid memory leakage
Fix some over allocation issues
Except for locale argument, always pass length instead of depend on \0 termination