### PR TITLE
Fix problems with overflowing buffer, add test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,8 @@
+using ICU
+using Base.Test
+
+# Tests for not overrunning buffer
+str = "\u3b0"
+upp = "\u3a5\u308\u301"
+
+@test u_strToUpper(utf16(str^8)) == utf16(upp^8)


### PR DESCRIPTION
This only allocates enough space for one character per input character (which will be correct most of the time, for most locales), but then retries with the actual size needed if it fails.
Previously, the code always allocated twice as much space as the input array, but could still get either a BoundsError or a general ErrorException if some of the characters expanded into 3 code units on output.
This also adds a simple test for one of the cases.