### PR TITLE
Support latest 58.1?

### DIFF
--- a/deps/versions.jl
+++ b/deps/versions.jl
@@ -1,2 +1,2 @@
-versions = 56:-1:36
+versions = 58:-1:36
 apt_versions = [52, 48, 42]


### PR DESCRIPTION
http://site.icu-project.org/download

This is entirely untested, seems maybe this simple to upgrade.. [Unclear to me if apt_versions needs updating; or should be in sync.. PR may only support 58, not 58.1?]

This isn't something I need or use, I just noticed Unicode 9.0 is now supported, so maybe useful (I know utf8proc already supports; this may not be needed, juts better with?).

[skip ci]